### PR TITLE
Update omniauth to 2.0 and bump version to 1.3

### DIFF
--- a/lib/omniauth/yahoo_oauth2/version.rb
+++ b/lib/omniauth/yahoo_oauth2/version.rb
@@ -1,5 +1,5 @@
 module OmniAuth
   module YahooOauth2
-    VERSION = '1.2.0'
+    VERSION = '1.3.0'
   end
 end

--- a/omniauth-oauth2-yahoo.gemspec
+++ b/omniauth-oauth2-yahoo.gemspec
@@ -5,15 +5,15 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency 'omniauth-oauth2', '~> 1.1'
   gem.add_development_dependency 'bundler', '~> 2'
 
-  gem.authors       = ['Amir Manji']
-  gem.email         = ['amanji75@gmail.com']
+  gem.authors       = ['Kristoffer Ek', 'Josef Ngo', 'Sten Larsson']
+  gem.email         = ['kristoffer.ek@burtcorp.com', 'josef.ngo@burtcorp.com', 'sten@burtcorp.com']
   gem.description   = 'A Yahoo OAuth2 strategy for OmniAuth.'
   gem.summary       = gem.description
-  gem.homepage      = 'https://github.com/amirmanji/omniauth-yahoo-oauth2'
+  gem.homepage      = 'https://github.com/burtcorp/omniauth-yahoo-oauth2'
   gem.license       = 'MIT'
 
   gem.files         = `git ls-files`.split("\n")
-  gem.name          = 'omniauth-yahoo-oauth2'
+  gem.name          = 'omniauth-oauth2-yahoo'
   gem.require_paths = ['lib']
   gem.version       = OmniAuth::YahooOauth2::VERSION
 end

--- a/omniauth-yahoo-oauth2.gemspec
+++ b/omniauth-yahoo-oauth2.gemspec
@@ -1,9 +1,9 @@
 require File.expand_path(File.join('..', 'lib', 'omniauth', 'yahoo_oauth2', 'version'), __FILE__)
 
 Gem::Specification.new do |gem|
-  gem.add_runtime_dependency 'omniauth', '~> 1.1'
+  gem.add_runtime_dependency 'omniauth', '~> 2.0'
   gem.add_runtime_dependency 'omniauth-oauth2', '~> 1.1'
-  gem.add_development_dependency 'bundler', '~> 1.0'
+  gem.add_development_dependency 'bundler', '~> 2'
 
   gem.authors       = ['Amir Manji']
   gem.email         = ['amanji75@gmail.com']


### PR DESCRIPTION
As other gems such as omniauth-snapchat requires a omniauth version of 2.0 it creates a conflict. This update should remove that conflict. Also bumped the bundler version.